### PR TITLE
feat: implement CreateTweetBox component

### DIFF
--- a/src/designsystem/AvatarButton/index.tsx
+++ b/src/designsystem/AvatarButton/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Avatar, AvatarProps } from "../Avatar";
 
-type AvatarButtonProps = AvatarProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
+export type AvatarButtonProps = AvatarProps & React.ButtonHTMLAttributes<HTMLButtonElement>;
 
 export const AvatarButton = ({
   imgSrc,

--- a/src/designsystem/AvatarLink/index.tsx
+++ b/src/designsystem/AvatarLink/index.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import Link, { LinkProps } from "next/link";
 import { Avatar, AvatarProps } from "../Avatar";
 
-type AvatarLinkProps = AvatarProps & LinkProps;
+export type AvatarLinkProps = AvatarProps & LinkProps;
 
 export const AvatarLink = ({ 
   imgSrc, alt, size, href 

--- a/src/designsystem/CreateTweetBox.stories.ts
+++ b/src/designsystem/CreateTweetBox.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { CreateTweetBox } from './CreateTweetBox';
+
+// More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
+const meta = {
+  title: 'Example/CreateTweetBox',
+  component: CreateTweetBox,
+  parameters: {
+    // Optional parameter to center the component in the Canvas. More info: https://storybook.js.org/docs/configure/story-layout
+    layout: 'centered',
+  },
+  // This component will have an automatically generated Autodocs entry: https://storybook.js.org/docs/writing-docs/autodocs
+  tags: ['autodocs'],
+  args: { onSubmit: fn(), onTextChange: fn() },
+} satisfies Meta<typeof CreateTweetBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
+export const Primary: Story = {
+  args: {
+    href: "https://twitter.com/X",
+    imgSrc: "https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcQRn2mZXaaCzPEIMQ80x-LDNZ2JQ6j0Q_J_tw&usqp=CAU",
+    alt: "avatar",
+  },
+};

--- a/src/designsystem/CreateTweetBox.tsx
+++ b/src/designsystem/CreateTweetBox.tsx
@@ -1,6 +1,5 @@
-import { useState } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
 import { Button } from "./Button";
-import clsx from "clsx";
 import { AvatarLink, AvatarLinkProps } from "./AvatarLink";
 
 interface CreateTweetBoxProps extends AvatarLinkProps {
@@ -17,51 +16,25 @@ export const CreateTweetBox = ({
 }: CreateTweetBoxProps) => {
     const [tweet, setTweet] = useState('');
 
-    const handleTextChange = (e: any) => {
-        console.log('changed!', tweet);
+    const handleTextChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
         onTextChange(tweet);
         setTweet(e.target.value);
     };
 
-    const handleSubmit = (e: any) => {
+    const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
-        console.log('submit!', tweet);
         onSubmit(tweet);
         setTweet('');
     };
 
-    const createTweetBoxClass = clsx(
-        "w-full flex flex-row px-4 py-1"
-    );
-
-    const avatarClass = clsx(
-        "mr-3.5"
-    );
-
-    const textAreaClass = clsx(
-        "bg-transparent text-[#d9d9d9] text-xl min-w-80 w-96 min-h-14"
-    );
-
-    const buttonsRowClass = clsx(
-        "flex flex-row"
-    );
-
-    const mediaButtonsClass = clsx(
-        "basis-3/4"
-    );
-
-    const tweetButtonClass = clsx(
-        "basis-1/4"
-    );
-
     return (
-        <div className={createTweetBoxClass}>
-            <div className={avatarClass}>
+        <div className="w-full flex flex-row px-4 py-1">
+            <div className="mr-3.5">
                 <AvatarLink href={href} imgSrc={imgSrc} alt={alt} size="small" />
             </div>
             <form onSubmit={handleSubmit}>
                 <textarea 
-                    className={textAreaClass}
+                    className="bg-transparent text-[#d9d9d9] text-xl min-w-80 w-96 min-h-14"
                     rows={2}
                     cols={33}
                     placeholder="What's happening?"
@@ -69,10 +42,14 @@ export const CreateTweetBox = ({
                     onChange={handleTextChange}
                     maxLength={218}
                 />
-                <div className={buttonsRowClass}>
-                    <div className={mediaButtonsClass}>Test Other Buttons</div>
-                    <div className={tweetButtonClass}>
-                        <Button type="submit" size="medium" disabled={tweet.length === 0}>Tweet</Button>
+                <div className="flex flex-row">
+                    <div className="basis-3/4">
+                        Other Media Buttons Placeholder
+                    </div>
+                    <div className="basis-1/4">
+                        <Button type="submit" size="medium" disabled={tweet.length === 0}>
+                            Tweet
+                        </Button>
                     </div>
                 </div>
             </form>

--- a/src/designsystem/CreateTweetBox.tsx
+++ b/src/designsystem/CreateTweetBox.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { Button } from "./Button";
+import clsx from "clsx";
+import { AvatarLink, AvatarLinkProps } from "./AvatarLink";
+
+interface CreateTweetBoxProps extends AvatarLinkProps {
+    onTextChange: (tweet: string) => void;
+    onSubmit: (tweet: string) => void;
+};
+
+export const CreateTweetBox = ({
+    onTextChange,
+    onSubmit,
+    href,
+    imgSrc,
+    alt,
+}: CreateTweetBoxProps) => {
+    const [tweet, setTweet] = useState('');
+
+    const handleTextChange = (e: any) => {
+        console.log('changed!', tweet);
+        onTextChange(tweet);
+        setTweet(e.target.value);
+    };
+
+    const handleSubmit = (e: any) => {
+        e.preventDefault();
+        console.log('submit!', tweet);
+        onSubmit(tweet);
+        setTweet('');
+    };
+
+    const createTweetBoxClass = clsx(
+        "w-full flex flex-row px-4 py-1"
+    );
+
+    const avatarClass = clsx(
+        "mr-3.5"
+    );
+
+    const textAreaClass = clsx(
+        "bg-transparent text-[#d9d9d9] text-xl min-w-80 w-96 min-h-14"
+    );
+
+    const buttonsRowClass = clsx(
+        "flex flex-row"
+    );
+
+    const mediaButtonsClass = clsx(
+        "basis-3/4"
+    );
+
+    const tweetButtonClass = clsx(
+        "basis-1/4"
+    );
+
+    return (
+        <div className={createTweetBoxClass}>
+            <div className={avatarClass}>
+                <AvatarLink href={href} imgSrc={imgSrc} alt={alt} size="small" />
+            </div>
+            <form onSubmit={handleSubmit}>
+                <textarea 
+                    className={textAreaClass}
+                    rows={2}
+                    cols={33}
+                    placeholder="What's happening?"
+                    value={tweet}
+                    onChange={handleTextChange}
+                    maxLength={218}
+                />
+                <div className={buttonsRowClass}>
+                    <div className={mediaButtonsClass}>Test Other Buttons</div>
+                    <div className={tweetButtonClass}>
+                        <Button type="submit" size="medium" disabled={tweet.length === 0}>Tweet</Button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    );
+};


### PR DESCRIPTION
This PR implements the CreateTweetBox component from https://github.com/users/dtalay/projects/3/views/1?pane=issue&itemId=51001277
<img width="680" alt="Screenshot 2024-02-06 at 2 53 31 PM" src="https://github.com/dtalay/twitter-clone-web/assets/108175707/358261e4-14f4-4f1d-994c-30a4033e143e">

It has `onTextChange` and `onSubmit` callback props. It also uses the AvatarLink component, since clicking the user's Avatar should lead to their profile.

It accepts a maximum of 218 characters, and the Button component is disabled at 0 characters.